### PR TITLE
프로젝트 화면 분기

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,9 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    dataBinding {
+        enabled = true
+    }
 }
 
 dependencies {
@@ -57,6 +60,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
     implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.GetYourPokemon">
         <activity
-            android:name=".MainActivity"
+            android:name="com.burningfriday.getyourpokemon.LaunchActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.GetYourPokemon.NoActionBar">
@@ -20,6 +20,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.burningfriday.getyourpokemon.ComposeListActivity"
+            android:exported="false"
+            android:theme="@style/Theme.GetYourPokemon.NoActionBar" />
+
+        <activity
+            android:name="com.burningfriday.getyourpokemon.ModernListActivity"
+            android:exported="false"
+            android:theme="@style/Theme.GetYourPokemon.NoActionBar" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/burningfriday/getyourpokemon/ComposeListActivity.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/ComposeListActivity.kt
@@ -1,4 +1,4 @@
-package com.android.getyourpokemon
+package com.burningfriday.getyourpokemon
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -8,9 +8,12 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.android.getyourpokemon.ui.theme.GetYourPokemonTheme
+import com.burningfriday.getyourpokemon.ui.theme.GetYourPokemonTheme
 
-class MainActivity : ComponentActivity() {
+/**
+ * @author Hyunwoo Choi
+ */
+class ComposeListActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/app/src/main/java/com/burningfriday/getyourpokemon/LaunchActivity.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/LaunchActivity.kt
@@ -1,0 +1,42 @@
+package com.burningfriday.getyourpokemon
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.databinding.DataBindingUtil
+import com.android.getyourpokemon.R
+import com.android.getyourpokemon.databinding.ActivityLaunchBinding
+
+/**
+ * @author Hyunwoo Choi
+ */
+class LaunchActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityLaunchBinding
+    private val viewModel: LaunchViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_launch)
+        binding.viewModel = viewModel
+
+        initObservers()
+    }
+
+    private fun initObservers() {
+        viewModel.event.observe(this) { eventWrapper ->
+            val event = eventWrapper.peekContent() as? LaunchEvent ?: return@observe
+            when(event) {
+                LaunchEvent.OnClickSampleAAC -> {
+                    startActivity(Intent(this, ModernListActivity::class.java))
+                }
+
+                LaunchEvent.OnClickSampleCompose -> {
+                    startActivity(Intent(this, ComposeListActivity::class.java))
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/burningfriday/getyourpokemon/LaunchEvent.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/LaunchEvent.kt
@@ -1,0 +1,11 @@
+package com.burningfriday.getyourpokemon
+
+import com.burningfriday.getyourpokemon.common.Event
+
+/**
+ * @author Hyunwoo Choi
+ */
+enum class LaunchEvent : Event {
+    OnClickSampleAAC,
+    OnClickSampleCompose,
+}

--- a/app/src/main/java/com/burningfriday/getyourpokemon/LaunchViewModel.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/LaunchViewModel.kt
@@ -1,0 +1,22 @@
+package com.burningfriday.getyourpokemon
+
+import com.burningfriday.getyourpokemon.common.BaseViewModel
+
+/**
+ * @author Hyunwoo Choi
+ */
+class LaunchViewModel : BaseViewModel() {
+
+    fun onClickSampleAAC() {
+        invokeEvent(
+            LaunchEvent.OnClickSampleCompose
+        )
+    }
+
+    fun onClickSampleCompose() {
+        invokeEvent(
+            LaunchEvent.OnClickSampleCompose
+        )
+    }
+
+}

--- a/app/src/main/java/com/burningfriday/getyourpokemon/LaunchViewModel.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/LaunchViewModel.kt
@@ -9,7 +9,7 @@ class LaunchViewModel : BaseViewModel() {
 
     fun onClickSampleAAC() {
         invokeEvent(
-            LaunchEvent.OnClickSampleCompose
+            LaunchEvent.OnClickSampleAAC
         )
     }
 

--- a/app/src/main/java/com/burningfriday/getyourpokemon/ModernListActivity.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/ModernListActivity.kt
@@ -1,0 +1,29 @@
+package com.burningfriday.getyourpokemon
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.databinding.DataBindingUtil
+import androidx.lifecycle.Observer
+import com.android.getyourpokemon.R
+import com.android.getyourpokemon.databinding.ActivityModernListBinding
+
+class ModernListActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityModernListBinding
+    private val viewModel: ModernListViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_modern_list)
+        binding.viewModel = viewModel
+        initObservers()
+    }
+
+    private fun initObservers() {
+        viewModel.event.observe(this) {
+            // do something
+        }
+    }
+
+}

--- a/app/src/main/java/com/burningfriday/getyourpokemon/ModernListViewModel.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/ModernListViewModel.kt
@@ -1,0 +1,6 @@
+package com.burningfriday.getyourpokemon
+
+import com.burningfriday.getyourpokemon.common.BaseViewModel
+
+class ModernListViewModel : BaseViewModel() {
+}

--- a/app/src/main/java/com/burningfriday/getyourpokemon/common/BaseViewModel.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/common/BaseViewModel.kt
@@ -1,0 +1,22 @@
+package com.burningfriday.getyourpokemon.common
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+/**
+ * @author Hyunwoo Choi
+ */
+abstract class BaseViewModel : ViewModel() {
+
+    private val _event = MutableLiveData<EventWrapper<Event>>()
+    val event: LiveData<EventWrapper<Event>>
+        get() = _event
+
+    fun invokeEvent(e: Event) {
+        _event.postValue(
+            EventWrapper(e)
+        )
+    }
+
+}

--- a/app/src/main/java/com/burningfriday/getyourpokemon/common/Event.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/common/Event.kt
@@ -1,0 +1,6 @@
+package com.burningfriday.getyourpokemon.common
+
+/**
+ * @author Hyunwoo Choi
+ */
+interface Event

--- a/app/src/main/java/com/burningfriday/getyourpokemon/common/EventWrapper.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/common/EventWrapper.kt
@@ -1,0 +1,29 @@
+package com.burningfriday.getyourpokemon.common
+
+/**
+ * @see <p>https://medium.com/androiddevelopers/livedata-with-snackbar-navigation-and-other-events-the-singleliveevent-case-ac2622673150</p>
+ * todo : LiveData 이벤트 전달을 Flow 로 개선 후 삭제
+ */
+open class EventWrapper<out T>(private val content: T) {
+
+    var hasBeenHandled = false
+        private set // Allow external read but not write
+
+    /**
+     * Returns the content and prevents its use again.
+     */
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    /**
+     * Returns the content, even if it's already been handled.
+     */
+    fun peekContent(): T = content
+
+}

--- a/app/src/main/java/com/burningfriday/getyourpokemon/ui/theme/Color.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.android.getyourpokemon.ui.theme
+package com.burningfriday.getyourpokemon.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/burningfriday/getyourpokemon/ui/theme/Shape.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/ui/theme/Shape.kt
@@ -1,4 +1,4 @@
-package com.android.getyourpokemon.ui.theme
+package com.burningfriday.getyourpokemon.ui.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes

--- a/app/src/main/java/com/burningfriday/getyourpokemon/ui/theme/Theme.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.android.getyourpokemon.ui.theme
+package com.burningfriday.getyourpokemon.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme

--- a/app/src/main/java/com/burningfriday/getyourpokemon/ui/theme/Type.kt
+++ b/app/src/main/java/com/burningfriday/getyourpokemon/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.android.getyourpokemon.ui.theme
+package com.burningfriday.getyourpokemon.ui.theme
 
 import androidx.compose.material.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/res/layout/activity_launch.xml
+++ b/app/src/main/res/layout/activity_launch.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.burningfriday.getyourpokemon.LaunchViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.burningfriday.getyourpokemon.LaunchActivity">
+
+        <Button
+            android:id="@+id/btn_sample_aac"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Sample AAC"
+            android:onClick="@{() -> viewModel.onClickSampleAAC()}"
+            app:layout_constraintVertical_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/btn_sample_compose" />
+
+        <Button
+            android:id="@+id/btn_sample_compose"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Sample Compose"
+            android:onClick="@{() -> viewModel.onClickSampleCompose()}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/btn_sample_aac"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/activity_modern_list.xml
+++ b/app/src/main/res/layout/activity_modern_list.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+    
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.burningfriday.getyourpokemon.ModernListViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout 
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.burningfriday.getyourpokemon.ModernListActivity">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>


### PR DESCRIPTION
주요 수정사항
- 패키지 변경 : `com.android.getyourpokemon` > `com.burningfriday.getyourpokemon`
- BaseViewModel 선언. 우선 LiveData 구독하여 이벤트 처리 (추후 Flow로 개선하기)
- LaunchActivity에서 액티비티 2개 이동 분기. (compose 예제 용도 / binding 예제 용도)
- 이벤트 처리 예제 추가 (`invokeEvent()` 동작 참고)